### PR TITLE
Nested brackets

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -41,7 +41,7 @@ for file in glob.glob('**/*.lua', recursive=True):
 					# found a text block
 					# the expected format is:
 					# "--[[ PageName:foo..."
-					if len(header.groups()) == 2 or header.group(5).lower() == 'header':
+					if header.group(5) and header.group(5).lower() == 'header':
 						# our "foo" was "header", which signifies this should be text on top of
 						# the page, but there's already a dedicated heading for the page
 						isHeader = True

--- a/parse.py
+++ b/parse.py
@@ -47,7 +47,7 @@ for file in glob.glob('**/*.lua', recursive=True):
 						isHeader = True
 					else:
 						# everything else gets h3
-						textBlock = '{} {}\n\n'.format('#' * HSIZE, header.group(1))
+						textBlock = '{} {}\n\n'.format('#' * HSIZE, header.group(2))
 
 					# store the page name and toggle reading mode
 					comment = header.group(1)


### PR DESCRIPTION
This adds support for nested brackets in docs comments. I've been using this in Aurora's docs for linking to other pages in the same wiki. [example](https://github.com/Haleth/Aurora/wiki/Color) | [source](https://github.com/Haleth/Aurora/blob/master/Skin/color.lua#L76)